### PR TITLE
add roles to postgresql.yml in sonarqube's group_vars/preproduction_example

### DIFF
--- a/group_vars/preproduction-example/sonarqube/postgresql.yml
+++ b/group_vars/preproduction-example/sonarqube/postgresql.yml
@@ -6,3 +6,4 @@ postgresql_users:
   - username: sonarqube
     password: CHANGEME
     db: sonarqube
+    roles: CREATEDB


### PR DESCRIPTION
add `roles` variable to `postgresql.yml` in sonarqube's `group_vars/preproduction_example` as it's required in [postgresql_post.yml](https://github.com/opsta/ansible-postgresql/blob/6885e62ee78395a2e0a508075c9085ea96585695/tasks/postgresql_post.yml#L24)