### PR TITLE
remove deprecated nginx declarative

### DIFF
--- a/files/groups/example/nginx/conf.d/host.example.com.conf
+++ b/files/groups/example/nginx/conf.d/host.example.com.conf
@@ -9,7 +9,6 @@ server {
 
   listen 443 ssl;
 
-  ssl on;
   ssl_certificate_key /etc/nginx/certs/host-01.example.com.key;
   ssl_certificate /etc/nginx/certs/host-01.example.com.crt;
 

--- a/files/groups/example/nginx/conf.d/registry.example.com.conf
+++ b/files/groups/example/nginx/conf.d/registry.example.com.conf
@@ -9,7 +9,6 @@ server {
 
   listen 443 ssl;
 
-  ssl on;
   ssl_certificate_key /etc/nginx/certs/registry.example.com.key;
   ssl_certificate /etc/nginx/certs/registry.example.com.crt;
 


### PR DESCRIPTION
Remove Nginx `ssl: on` configuration because it was deprecated in the latest version.