### PR TITLE
use java runtime engine (jre) headless as graylog dependency instead

### DIFF
--- a/install-graylog.yml
+++ b/install-graylog.yml
@@ -3,7 +3,6 @@
   gather_facts: yes
   become: true
   roles:
-    - { role: opsta.java, when: graylog_all_in_one | default(false) }
     - { role: opsta.mongodb, when: graylog_all_in_one | default(false) }
     - { role: opsta.elasticsearch, when: graylog_all_in_one | default(false) }
     - opsta.graylog


### PR DESCRIPTION
If [the MR](https://github.com/opsta/ansible-graylog/pull/13) is acceptable, please consider this MR.